### PR TITLE
Fixed up code for deprecated syntax in 0.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.6
   - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 env:
     global:
     - PYTHON=conda

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
-NLsolve 0.9.1
-SymPy 0.5.1
+julia 0.6
+NLsolve 0.10.1
+SymPy 0.5.3
 JLD # Only needed for tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.6-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.6-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/constructor/expressions.jl
+++ b/src/constructor/expressions.jl
@@ -1,6 +1,6 @@
 
 function sympifyallexpressions(expressions::Array{String,1},leads_sym::Array{SymPy.Sym,1},vars::Array{String,1})
-    expressions_sym = Array(SymPy.Sym,length(expressions))
+    expressions_sym = Array{SymPy.Sym}(length(expressions))
 
     lags = createsymversions(vars,"_lag") # Create a list of all lagged variable - these are _potential_ states
     writtenlags = createsymversions(vars,"(-1)") # Preallocating this saves time, by not having to repeatedly call Sym
@@ -16,17 +16,17 @@ function sympifyallexpressions(expressions::Array{String,1},leads_sym::Array{Sym
         expressions_sym = SymPy.subs(expressions_sym,subsargs...)
     end
     
-    isstate = Array(Bool,length(lags))
+    isstate = BitArray(length(lags))
     fill!(isstate,false)
     
     for expression in expressions_sym
-        isstate = isstate | expressioncontains(expression,lags)
+        isstate = isstate .| expressioncontains(expression,lags)
     end
     
     # Now create the states array and indices array
     numstates = countnz(isstate)
-    states_sym = Array(SymPy.Sym,numstates)
-    states_indices = Array(Int,numstates)
+    states_sym = Array{SymPy.Sym}(numstates)
+    states_indices = Array{Int}(numstates)
     counter = 0
     for (i,state) in enumerate(lags)
         if isstate[i]

--- a/src/constructor/modeltypes.jl
+++ b/src/constructor/modeltypes.jl
@@ -1,16 +1,16 @@
-type RegimeParameterDecomposition
+mutable struct RegimeParameterDecomposition
     bar::Float64
     hat::Array{Float64,1}
 end
 
-type Block
+struct Block
     size::Int
-    equations::Array{Bool,1}
-    vars::Array{Bool,1}
-    states::Array{Bool,1}
+    equations::BitArray{1}
+    vars::BitArray{1}
+    states::BitArray{1}
 end
 
-immutable Meta
+struct Meta
     numstates::Int
     numvars::Int
     numshocks::Int
@@ -20,12 +20,12 @@ immutable Meta
     numexo::Int
 end
 
-immutable Parameters
+struct Parameters
     names::Array{String,1}
     values::Array{Float64,2}
     dictionary::Dict{String,Int}
-    isswitching::Array{Bool,1}
-    affectsSS::Array{Bool,1}
+    isswitching::BitArray{1}
+    affectsSS::BitArray{1}
     decomposition::Array{RegimeParameterDecomposition,1}
     values_withbar::Array{Float64,2}
     generic_sym::Array{SymPy.Sym,2}
@@ -34,44 +34,44 @@ immutable Parameters
     specificregime_sym::Array{SymPy.Sym,2}
 end
 
-immutable Variables
+struct Variables
     names::Array{String,1}
     dictionary::Dict{String,Int}
-    isstate::Array{Bool,1}
-    isstatic::Array{Bool,1}
-    isexo::Array{Bool,1}
+    isstate::BitArray
+    isstatic::BitArray
+    isexo::BitArray
     states_indices::Array{Int,1}
     states_sym::Array{SymPy.Sym,1}
     leads_sym::Array{SymPy.Sym,1}
     contemps_sym::Array{SymPy.Sym,1}
 end
 
-immutable Shocks
+struct Shocks
     names::Array{String,1}
     dictionary::Dict{String,Int}
     syms::Array{SymPy.Sym,1}
 end
 
-immutable Equations
+struct Equations
     stringversions::Array{String,1}
-    isstatic::Array{Bool,1}
-    isexo::Array{Bool,1}
+    isstatic::BitArray{1}
+    isexo::BitArray{1}
     syms::Array{SymPy.Sym,1}
 end
 
-type SteadyState # not immutable, because I need to wholesale reassign the steady state values all the time
+mutable struct SteadyState # mutable, because I need to wholesale reassign the steady state values all the time
     system::Array{Function,1}
     values::Array{Float64,1}
 end
 
-immutable TransitionMatrix
+struct TransitionMatrix
     values::Array{Float64,2}
     genericsyms::Array{SymPy.Sym,1}
     ergodic::Array{Float64,1}
     completelygeneric::SymPy.Sym
 end
 
-immutable PerturbationSystem
+struct PerturbationSystem
     A1::SparseMatrixCSC{Function}
     A2::SparseMatrixCSC{Function}
     A3::SparseMatrixCSC{Function}
@@ -92,15 +92,15 @@ immutable PerturbationSystem
     Js::Array{SymPy.Sym,3}
     Jx::Array{SymPy.Sym,2}
     Jz::Array{SymPy.Sym,2}
-    isJ::Array{Bool,1}
-    isY::Array{Bool,1}
-    isW::Array{Bool,1}
-    isZ::Array{Bool,1}
-    isX::Array{Bool,1}
-    blocks::Array{Block,1}
+    isJ::BitArray{1}
+    isY::BitArray{1}
+    isW::BitArray{1}
+    isZ::BitArray{1}
+    isX::BitArray{1}
+    blocks::BitArray{1}
 end
 
-type RSDSGEModel
+struct RSDSGEModel
     meta::Meta
     parameters::Parameters
     vars::Variables

--- a/src/constructor/parameters.jl
+++ b/src/constructor/parameters.jl
@@ -6,8 +6,8 @@ function RegimeParameterDecomposition(parameter_values::Array{Float64,1},ergodic
 end
 
 function formatparametervalues(numregimes,numparameters,parameter_values,parameter_names)
-    formatted = Array(Float64,numregimes,numparameters)
-    switching = Array(Bool,length(parameter_names))
+    formatted = Array{Float64}(numregimes,numparameters)
+    switching = BitArray(length(parameter_names))
     fill!(switching,false)
     for (p,value,name) in zip(1:numparameters,parameter_values,parameter_names)
         if !isa(value,Number)
@@ -25,15 +25,15 @@ function formatparametervalues(numregimes,numparameters,parameter_values,paramet
 end
 
 function createsymversions(vars::Array{String,1},suffix=""::String)
-    out = Array(SymPy.Sym,length(vars))
+    out = Array{SymPy.Sym}(length(vars))
     for (i,var) in enumerate(vars)
         out[i] = Sym(string(var,suffix))
     end
     return out
 end    
 
-function createsymparameters(names::Array{String,1},switches::Array{Bool,1})
-    out = Array(SymPy.Sym,2,length(names))
+function createsymparameters(names::Array{String,1},switches::BitArray{1})
+    out = Array{SymPy.Sym}(2,length(names))
     for (i,name,switch) in zip(1:length(names),names,switches)
         if switch
             out[1,i] = Sym("$(name)_R")
@@ -46,9 +46,9 @@ function createsymparameters(names::Array{String,1},switches::Array{Bool,1})
     return out
 end
 
-function createSSparameters(numparameters::Int,parameter_affectsSS::Array{Bool,1},barversions::Array{SymPy.Sym},
-			     parameter_names::Array{String},parameters::Array{SymPy.Sym},switching::Array{Bool,1})
-    parametersSS = Array(SymPy.Sym,numparameters)
+function createSSparameters(numparameters::Int,parameter_affectsSS::BitArray{1},barversions::Array{SymPy.Sym},
+			     parameter_names::Array{String},parameters::Array{SymPy.Sym},switching::BitArray{1})
+    parametersSS = Array{SymPy.Sym}(numparameters)
     for p = 1:numparameters
         if parameter_affectsSS[p]
             parametersSS[p] = barversions[p]
@@ -66,9 +66,9 @@ end
 function decomposeparameters(parameters,switching,affectsSS,parameter_values,ergodic,numparameters,numregimes)
     
     # Preallocate output arrays
-    parameter_decomposition = Array(RegimeParameterDecomposition,numparameters)
-    parameter_bar_sym = Array(SymPy.Sym,numparameters)
-    parameter_regime_sym = Array(SymPy.Sym,numregimes,numparameters)
+    parameter_decomposition = Array{RegimeParameterDecomposition}(numparameters)
+    parameter_bar_sym = Array{SymPy.Sym}(numparameters)
+    parameter_regime_sym = Array{SymPy.Sym}(numregimes,numparameters)
     
     sympyzero = Sym(0.0)
     
@@ -96,7 +96,7 @@ function decomposeparameters(parameters,switching,affectsSS,parameter_values,erg
 end
 
 function creategenerichats(names,affectsSS)
-    generics = Array(SymPy.Sym,2,length(affectsSS))
+    generics = Array{SymPy.Sym}(2,length(affectsSS))
     sympyzero = Sym(0.0)
     for (i,name) in enumerate(names)
         if affectsSS[i]

--- a/src/constructor/parsefile.jl
+++ b/src/constructor/parsefile.jl
@@ -72,7 +72,7 @@ end
 
 function parsetransmatrix(transmatrixstring)
     numregimes = length(transmatrixstring)
-    transmatrix = Array(Float64,numregimes,numregimes)
+    transmatrix = Array{Float64}(numregimes,numregimes)
     for r in 1:numregimes
 	if r == 1
 	    # First line, need to strip off the first bit
@@ -125,7 +125,7 @@ function splitonequals(input)
 end
 
 function parseparametervalues(values,parameters)
-    parametervalues = Array(Any,length(parameters))
+    parametervalues = Array{Any}(length(parameters))
     values_dict = splitonequals(values)
     unset = trues(length(parameters))
     for (key,val) in values_dict
@@ -143,7 +143,7 @@ function parseparametervalues(values,parameters)
 end
 
 function parseequations(equations)
-    out = Array(String,length(equations))
+    out = Array{String}(length(equations))
     for i in eachindex(equations)
 	out[i] = strip(equations[i])
     end
@@ -153,7 +153,7 @@ end
 
 function splitoncomma(in)
     list = split(in,",")
-    out = Array(String,length(list))
+    out = Array{String}(length(list))
     for i in eachindex(list)
 	out[i] = strip(list[i])
     end

--- a/src/constructor/transmatrix.jl
+++ b/src/constructor/transmatrix.jl
@@ -1,8 +1,8 @@
 function getergodic(transmatrix::Array{Float64,2})
     D,V = eig(transmatrix')
-    eigindex = indmin(abs(D-1.0))
+    eigindex = indmin(abs.(D-1.0))
     ergodic = vec(V[:,eigindex]/sum(V[:,eigindex]))
-    if any(abs(imag(ergodic)).>1e-16)
+    if any(abs.(imag(ergodic)).>1e-16)
         error("Imaginary ergodic distribution")
     else
         return real(ergodic)
@@ -10,7 +10,7 @@ function getergodic(transmatrix::Array{Float64,2})
 end
 
 function createtransmatrix_sym(numregimes::Int)
-    out = Array(SymPy.Sym,numregimes)
+    out = Array{SymPy.Sym}(numregimes)
     for j = 1:numregimes
         out[j] = Sym("TRANSITIONPROBABILITY_RX_RP$(j)")
     end
@@ -23,7 +23,7 @@ function TransitionMatrix(trans)
     if size(trans,2)!=size(trans,1)
         error("Regime transition matrix is not square.")
     end
-    if any((abs(sum(trans,2))-1.0).>1e-12)
+    if any((abs.(sum(trans,2))-1.0).>1e-12)
         error("Rows of the regime transition matrix do not sum to 1.")
     end
     # Create a sympy version of the regime trans matrix

--- a/src/constructor/utils.jl
+++ b/src/constructor/utils.jl
@@ -40,7 +40,7 @@ end
 
 function checknames(names::Array{String})
     # This function throws an error for names that are unacceptable/reserved in sympy (i.e. pi, inf etc)
-    badnames = Array(String,0)
+    badnames = Array{String}(0)
     push!(badnames,"Inf")
     push!(badnames,"inf")
     push!(badnames,"exp")

--- a/src/modelutils.jl
+++ b/src/modelutils.jl
@@ -1,11 +1,11 @@
 function findSS!(model::RSDSGEModel,guess::Array{Float64,1})
-    ssparameters = Array(Float64,model.meta.numparameters)
+    ssparameters = Array{Float64}(model.meta.numparameters)
     for (p,affects) in enumerate(model.parameters.affectsSS)
         if affects
             ssparameters[p] = model.parameters.decomposition[p].bar
         end
     end
-    ssparameters[!model.parameters.affectsSS] = model.parameters.values[1,!model.parameters.affectsSS]
+    ssparameters[.!model.parameters.affectsSS] = model.parameters.values[1, .!model.parameters.affectsSS]
     
     sswrapper = x->evaluateSS(model.steadystate.system,x,ssparameters)
     print("Solving for steady state...")


### PR DESCRIPTION
Mostly to do with adding .s for broadcasting functions like ! and | and &